### PR TITLE
runs out of box after npm install

### DIFF
--- a/bin/jsiohint
+++ b/bin/jsiohint
@@ -4,6 +4,8 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 var jsio = require('jsio');
 var JSHINT = require('jshint').JSHINT;
+var path = require('path');
+
 jsio('import preprocessors.cls as cls');
 jsio('import preprocessors.import as importc');
 
@@ -16,18 +18,20 @@ var preprocess = function(path, src) {
 	return def.src;
 };
 
+var jshint = path.join(__dirname, '../node_modules/jshint/bin/jshint');
+
 var filename = process.argv[2];
 if (filename) {
-    var preprocessed = preprocess('.', fs.readFileSync(process.argv[2], 'utf-8'));
-    var jshintProcess = spawn('./node_modules/jshint/bin/jshint', ['-']);
-    jshintProcess.stdout.pipe(process.stdout);
-    jshintProcess.stderr.pipe(process.stderr);
+  var preprocessed = preprocess('.', fs.readFileSync(process.argv[2], 'utf-8'));
+  var jshintProcess = spawn(jshint, ['-']);
 
-    jshintProcess.on('exit', function(code) {
-        process.exit(code);
-    });
+  jshintProcess.stdout.pipe(process.stdout);
+  jshintProcess.stderr.pipe(process.stderr);
 
-    jshintProcess.stdin.setEncoding('utf-8');
-    jshintProcess.stdin.write(preprocessed + '\n', 'utf-8');
-    jshintProcess.stdin.end();
+  jshintProcess.on('exit', function(code) {
+    process.exit(code);
+  });
+
+  jshintProcess.stdin.write(preprocessed + '\n', 'utf-8');
+  jshintProcess.stdin.end();
 }

--- a/bin/jsiohint
+++ b/bin/jsiohint
@@ -20,11 +20,20 @@ var preprocess = function(path, src) {
 
 var jshint = path.join(__dirname, '../node_modules/jshint/bin/jshint');
 
-var filename = process.argv[2];
-if (filename) {
-  var preprocessed = preprocess('.', fs.readFileSync(process.argv[2], 'utf-8'));
-  var jshintProcess = spawn(jshint, ['-']);
+var filename = process.argv[process.argv.length - 1];
+var filenameIsValid = filename[0] !== '-';
 
+if (filenameIsValid) {
+  var preprocessed = preprocess('.', fs.readFileSync(filename, 'utf-8'));
+
+  // Get remaining arguments
+  var args = process.argv.slice(2, -1);
+  args.push('-');
+
+  // Spawn jshint
+  var jshintProcess = spawn(jshint, args);
+
+  // pipe to process
   jshintProcess.stdout.pipe(process.stdout);
   jshintProcess.stderr.pipe(process.stderr);
 
@@ -34,4 +43,15 @@ if (filename) {
 
   jshintProcess.stdin.write(preprocessed + '\n', 'utf-8');
   jshintProcess.stdin.end();
+} else {
+  // Probably just doing a -h or something
+  var p = spawn(jshint, process.argv.slice(2));
+
+  p.on('exit', function(code) {
+    process.exit(code);
+  });
+
+  p.stdout.pipe(process.stdout);
+  p.stderr.pipe(process.stderr);
 }
+

--- a/bin/jsiohint
+++ b/bin/jsiohint
@@ -5,6 +5,60 @@ var spawn = require('child_process').spawn;
 var jsio = require('jsio');
 var JSHINT = require('jshint').JSHINT;
 var path = require('path');
+var Transform = require('stream').Transform;
+var util = require('util');
+var StringDecoder = require('string_decoder').StringDecoder;
+util.inherits(StringReplaceTransformStream, Transform);
+
+// Gets \n-delimited things and replaces rstring occurrences with replacement
+function StringReplaceTransformStream (rstring, replacement) {
+  Transform.call(this, {encoding: 'utf8'});
+
+  this._rstring = rstring;
+  this._replacement = replacement;
+
+  this._buffer = '';
+  this._decoder = new StringDecoder('utf8');
+}
+
+StringReplaceTransformStream.prototype._transform = function (chunk, enc, cb) {
+  this._buffer += this._decoder.write(chunk);
+  // split on newlines
+  var lines = this._buffer.split(/\r?\n/);
+
+  // keep the last partial line buffered
+  this._buffer = lines.pop();
+
+  for (var l=0; l != lines.length; l++) {
+    var line = lines[l];
+    try {
+      var res = line.replace(this._rstring, this._replacement) + '\n';
+    } catch (err) {
+      this.emit('error', err);
+      return;
+    }
+
+    this.push(res);
+  }
+
+  cb();
+};
+
+StringReplaceTransformStream.prototype._flush = function (cb) {
+  // handle leftovers
+  var rem = this._buffer.trim();
+  if (rem) {
+    try {
+      var res = line.replace(this._rstring, this._replacement) + '\n';
+    } catch (err) {
+      this.emit('error', err);
+      return;
+    }
+    // push the parsed object out to the readable consumer
+    this.push(res);
+  }
+  cb();
+};
 
 jsio('import preprocessors.cls as cls');
 jsio('import preprocessors.import as importc');
@@ -33,8 +87,10 @@ if (filenameIsValid) {
   // Spawn jshint
   var jshintProcess = spawn(jshint, args);
 
-  // pipe to process
-  jshintProcess.stdout.pipe(process.stdout);
+  var transform = new StringReplaceTransformStream(/stdin/, filename);
+
+  jshintProcess.stdout.pipe(transform);
+  transform.pipe(process.stdout);
   jshintProcess.stderr.pipe(process.stderr);
 
   jshintProcess.on('exit', function(code) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsiohint",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A jsio flavored CLI for JSHint",
   "homepage": "http://github.com/gameclosure/jsiohint",
   "author": {

--- a/package.json
+++ b/package.json
@@ -6,17 +6,23 @@
   "author": {
     "name": "Tom Fairfield"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  }],
-  "bin": { "jsiohint": "./bin/jsiohint" },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "bin": {
+    "jsiohint": "./bin/jsiohint"
+  },
   "files": [
     "README.md",
     "LICENSE",
     "bin/jsiohint"
   ],
   "dependencies": {
+    "jshint": "~2.5.1",
+    "jsio": "~1.0.4"
   },
-  "preferGlobal" : true
+  "preferGlobal": true
 }


### PR DESCRIPTION
- Fixes issues where no dependencies were specified, but it explicitly relied on a local installation of `jshint` and `jsio`.
- Fixes path to `jshint` executable script
- Adds support for `jshint` command line arguments
- Fixes syntastic integration
